### PR TITLE
into tracker:development from tracker:task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 # Ignore gemset files
 /.ruby-gemset
 /.ruby-version
+
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'swagger-docs'
 
 group :development, :test do
   gem 'active_cucumber'
+  gem 'byebug'
   gem 'capybara'
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     ast (2.2.0)
     attr_defaultable (0.0.3)
     builder (3.2.2)
+    byebug (9.0.6)
     capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
@@ -214,6 +215,7 @@ DEPENDENCIES
   active_model_serializers
   annotate
   attr_defaultable
+  byebug
   capybara
   cucumber-rails
   database_cleaner
@@ -242,4 +244,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/app/controllers/v1/projects_controller.rb
+++ b/app/controllers/v1/projects_controller.rb
@@ -22,7 +22,7 @@ module V1
       param :path, :id, :string, :required, 'User Id'
     end
     def show
-      project = Project.find_by params[:id]
+      project = Project.find_by_id params[:id]
       if project.present?
         render json: project
       else
@@ -51,7 +51,7 @@ module V1
       param :form, :description, :string, :optional, 'Project description'
     end
     def update
-      project = Project.find_by params[:id]
+      project = Project.find_by_id params[:id]
       if project.present? && project.update_attributes(project_params)
         render json: project
       elsif project.present?
@@ -66,7 +66,7 @@ module V1
       param :path, :id, :string, :required, 'Project Id'
     end
     def destroy
-      project = Project.find_by params[:id]
+      project = Project.find_by_id params[:id]
       if project.present? && project.update_attributes(state: :disabled)
         render json: project
       elsif project.present?

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -1,0 +1,92 @@
+module V1
+  class TasksController < ApplicationController
+    swagger_controller :tasks, 'Tasks'
+    before_action :set_task, only: [:show, :update, :destroy]
+
+    swagger_api :index do
+      summary 'List all tasks'
+      notes 'This lists all the tasks for a task'
+      param :project_id, :uuid
+      param :query, :page, :integer, :optional, 'page number of results, default 1'
+      param :query, :page_size, :integer, :optional, 'number of results per page, default 25'
+    end
+    def index
+      tasks, errors = ListTasks.new(index_params).call
+      if errors.any?
+        render json: { errors: errors }, status: 400
+      else
+        render json: tasks
+      end
+    end
+
+    swagger_api :show do
+      summary 'Fetch a single task'
+      param :path, :id, :string, :required, 'Task Id'
+    end
+    def show
+      if @task.present?
+        render json: @task
+      else
+        render json: { errors: ['Task not found'] }, status: 404
+      end
+    end
+
+    swagger_api :create do
+      summary 'Creates a new Task'
+      param :form, :name, :string, :required, 'Task designation'
+      param :form, :description, :string, :optional, 'Task description'
+    end
+    def create
+      task = Task.new task_params
+      if task.save
+        render json: task, status: 201
+      else
+        render json: { errors: task.errors.full_messages }, status: 400
+      end
+    end
+
+    swagger_api :update do
+      summary 'Updates an existing Task'
+      param :path, :id, :string, :required, 'Task Id'
+      param :form, :name, :string, :optional, 'Task designation'
+      param :form, :description, :string, :optional, 'Task description'
+    end
+    def update
+      if @task.present? && @task.update_attributes(task_params)
+        render json: @task
+      elsif @task.present?
+        render json: { errors: @task.errors.full_messages }, status: 400
+      else
+        render json: { errors: ['Task not found'] }, status: 404
+      end
+    end
+
+    swagger_api :destroy do
+      summary 'Deletes an existing Task'
+      param :path, :id, :string, :required, 'Task Id'
+    end
+    def destroy
+      if @task.present? && @task.update_attributes(state: :done)
+        render json: @task
+      elsif @task.present?
+        render json: { errors: @task.errors.full_messages }, status: 400
+      else
+        render json: { errors: ['Task not found'] }, status: 404
+      end
+    end
+
+    private
+
+    def index_params
+      params.permit(:task_id, :page, :page_size).to_h.symbolize_keys
+    end
+
+    def task_params
+      params.require(:task).permit(:project_id, :name, :description, :state)
+    end
+
+    def set_task
+      @task = Task.find_by params[:id]
+    end
+  end
+end

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -84,9 +84,7 @@ module V1
     end
 
     def task_params
-      params.require(:task)
-            .permit(:project_id, :name, :description, :state)
-            .reject { |_, v| v.blank? }
+      params.require(:task).permit(:project_id, :name, :description, :state)
     end
 
     def set_task

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -82,11 +82,13 @@ module V1
     end
 
     def task_params
-      params.require(:task).permit(:project_id, :name, :description, :state)
+      params.require(:task)
+            .permit(:project_id, :name, :description, :state)
+            .reject { |_, v| v.blank? }
     end
 
     def set_task
-      @task = Task.find_by params[:id]
+      @task = Task.find_by_id params[:id]
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,8 @@
 #
 
 class Project < ActiveRecord::Base
+  has_many :tasks
+
   validates :name, presence: true, uniqueness: true
   validates :state, presence: true
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id               :uuid             not null, primary key
+#  name             :string
+#  description      :string
+#  state            :integer
+#  project_id       :uuid
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+class Task < ActiveRecord::Base
+  belongs_to :project
+
+  validates :name, presence: true, uniqueness: true
+  validates :state, presence: true
+  validates :project_id, presence: true
+
+  after_initialize :set_default_state
+
+  enum state: {
+    todo: 10,
+    in_progress: 20,
+    completed: 30
+  }
+
+  def project_name
+    project.name
+  end
+
+  private
+
+  def set_default_state
+    self.state ||= :todo
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,8 +23,10 @@ class Task < ActiveRecord::Base
   enum state: {
     todo: 10,
     in_progress: 20,
-    completed: 30
+    done: 30
   }
+
+  scope :incomplete, -> { where.not(id: done) }
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -26,10 +26,6 @@ class Task < ActiveRecord::Base
     completed: 30
   }
 
-  def project_name
-    project.name
-  end
-
   private
 
   def set_default_state

--- a/app/serializers/v1/project_serializer.rb
+++ b/app/serializers/v1/project_serializer.rb
@@ -1,7 +1,5 @@
 module V1
   class ProjectSerializer < ActiveModel::Serializer
-
     attributes :id, :name, :description, :state
-
   end
 end

--- a/app/serializers/v1/task_serializer.rb
+++ b/app/serializers/v1/task_serializer.rb
@@ -1,0 +1,7 @@
+module V1
+  class TaskSerializer < ActiveModel::Serializer
+
+    attributes :id, :name, :description, :state, :project_id
+
+  end
+end

--- a/app/serializers/v1/task_serializer.rb
+++ b/app/serializers/v1/task_serializer.rb
@@ -1,7 +1,5 @@
 module V1
   class TaskSerializer < ActiveModel::Serializer
-
     attributes :id, :name, :description, :state, :project_id
-
   end
 end

--- a/app/services/list_tasks.rb
+++ b/app/services/list_tasks.rb
@@ -8,7 +8,7 @@ class ListTasks < ListCollection
   end
 
   def collection
-    @tasks ||= task_respository
+    @tasks ||= task_respository.incomplete
   end
 
 end

--- a/app/services/list_tasks.rb
+++ b/app/services/list_tasks.rb
@@ -8,7 +8,7 @@ class ListTasks < ListCollection
   end
 
   def collection
-    @tasks ||= task_respository.todo
+    @tasks ||= task_respository
   end
 
 end

--- a/app/services/list_tasks.rb
+++ b/app/services/list_tasks.rb
@@ -1,0 +1,14 @@
+class ListTasks < ListCollection
+
+  attr_defaultable :task_respository, -> { Task }
+  attr_defaultable :result_serializer, -> { V1::TaskSerializer }
+
+  def collection_type
+    :tasks
+  end
+
+  def collection
+    @tasks ||= task_respository.todo
+  end
+
+end

--- a/config/initializers/swagger_docs.rb
+++ b/config/initializers/swagger_docs.rb
@@ -1,4 +1,4 @@
-Swagger::Docs::Config.base_api_controller = ApplicationController
+Swagger::Docs::Config.base_api_controller = ActionController::API
 Swagger::Docs::Config.register_apis({
   '1.0' => {
     api_extension_type: :json,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
 
   namespace :v1 do
     resources :projects, only: crud
+    resources :tasks, only: crud
   end
 end

--- a/db/migrate/20161026233051_create_tasks.rb
+++ b/db/migrate/20161026233051_create_tasks.rb
@@ -1,0 +1,13 @@
+class CreateTasks < ActiveRecord::Migration
+  def change
+    create_table :tasks, id: :uuid do |t|
+      t.string :name
+      t.index :name, unique: true
+      t.string :description
+      t.integer :state, default: 10
+      t.uuid :project_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160526161257) do
+ActiveRecord::Schema.define(version: 20161026233051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,5 +26,16 @@ ActiveRecord::Schema.define(version: 20160526161257) do
   end
 
   add_index "projects", ["name"], name: "index_projects_on_name", unique: true, using: :btree
+
+  create_table "tasks", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.string   "name"
+    t.string   "description"
+    t.integer  "state",       default: 10
+    t.uuid     "project_id"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  add_index "tasks", ["name"], name: "index_tasks_on_name", unique: true, using: :btree
 
 end

--- a/features/step_definitions/task_steps.rb
+++ b/features/step_definitions/task_steps.rb
@@ -1,0 +1,20 @@
+Given(/^(\d+) tasks?$/) do |count|
+  d.given_tasks count: count
+end
+
+Given(/^a task:$/) do |table|
+  d.given_task table
+end
+
+When(/^I (?:try to )?create a task with:$/) do |table|
+  attributes = vertical_table table
+  d.create_task attributes
+end
+
+Then(/^the system has the tasks:$/) do |table|
+  ActiveCucumber.diff_all! Task.order(:created_at), table
+end
+
+Then(/^the system has (\d+) tasks?$/) do |count|
+  expect(Task.count).to eq count.to_i
+end

--- a/features/support/world_drivers/domain_world_driver.rb
+++ b/features/support/world_drivers/domain_world_driver.rb
@@ -15,4 +15,8 @@ class DomainWorldDriver < WorldDriver
     @errors.push *project.errors.full_messages
   end
 
+  def create_task params
+    task = Task.create params
+    @errors.push *task.errors.full_messages
+  end
 end

--- a/features/support/world_drivers/world_driver.rb
+++ b/features/support/world_drivers/world_driver.rb
@@ -22,6 +22,20 @@ class WorldDriver
     ActiveCucumber.create_one Project, data
   end
 
+  def given_tasks count: nil, data: nil
+    if count.present?
+      FactoryGirl.create_list :task, count.to_i
+    elsif data.present?
+      ActiveCucumber.create_many Task, data
+    else
+      fail 'No tasks given'
+    end
+  end
+
+  def given_task data
+    ActiveCucumber.create_one Task, data
+  end
+
   def check_unexpected_errors
     errors.present? && fail("Unexpected errors happened:\n #{errors.join("\n")}")
   end

--- a/features/tasks/create_tasks.feature
+++ b/features/tasks/create_tasks.feature
@@ -1,0 +1,44 @@
+@domain @api
+Feature: Creating tasks
+
+  Rules:
+  - Name is required
+  - Project is required
+  - Created tasks should default to "todo" state
+
+  Scenario: Creating a task with all fields
+    Given a project:
+      | ID          | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+      | NAME        | Sample Project                       |
+      | DESCRIPTION | A small sample project               |
+      | STATE       | active                               |
+    When I create a task with:
+      | NAME              | Sample Task                           |
+      | DESCRIPTION       | This is a sample task.                |
+      | PROJECT_ID        | 54f8419c-3f22-4cba-b194-5f8b4727ccfd  |
+      | STATE             | todo                                  |
+    Then the system has the tasks:
+      | NAME           | STATE              | PROJECT_ID                            |
+      | Sample Task    | todo               | 54f8419c-3f22-4cba-b194-5f8b4727ccfd  |
+
+
+  Scenario: Trying to create a task without a name
+    Given a project:
+      | ID          | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+      | NAME        | Sample Project                       |
+      | DESCRIPTION | A small sample project               |
+      | STATE       | active                               |
+    When I try to create a task with:
+      | DESCRIPTION             | This is a sample task.               |
+      | STATE                   | todo                                 |
+      | PROJECT_ID              | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+    Then the system has 0 tasks
+    And I get the error "Name can't be blank"
+
+  Scenario: Trying to create a task without a project
+    When I try to create a task with:
+      | NAME                   | Some sample task.         |
+      | DESCRIPTION            | This is a sample task.    |
+      | STATE                  | todo                      |
+    Then the system has 0 tasks
+    And I get the error "Project can't be blank"

--- a/features/tasks/list_tasks.feature
+++ b/features/tasks/list_tasks.feature
@@ -1,0 +1,83 @@
+@domain @api
+Feature: Listing tasks
+
+  Rules:
+  - if a negative page is requested, an error is thrown
+  - if a page that is too high is requested, the last page is returned
+  - if a negative page_size is requested, the default size is used
+
+
+  Scenario: No parameters are specified and there are 26 tasks
+    Given 26 tasks
+    When I request the tasks list
+    Then I get 25 tasks back
+    And the current page is 1
+    And the total pages is 2
+    And the total results is 26
+
+
+  Scenario: Specifying parameters for the last tasks page
+    Given 3 tasks
+    When I request the tasks list with parameters:
+      | PAGE_SIZE | 2 |
+      | PAGE      | 2 |
+    Then I get 1 task back
+    And the current page is 2
+    And the total pages is 2
+    And the total results is 3
+
+
+  Scenario: The specified page is outside of the acceptable range
+    Given 3 tasks
+    When I request the tasks list with parameters:
+      | PAGE_SIZE | 2 |
+      | PAGE      | 5 |
+    Then I get 1 task back
+    And the current page is 2
+    And the total pages is 2
+    And the total results is 3
+
+
+  Scenario: The specified page size is greater than the number of tasks
+    Given 2 tasks
+    When I request the tasks list with parameters:
+      | PAGE_SIZE | 10 |
+      | PAGE      | 1  |
+    Then I get 2 tasks back
+    And the current page is 1
+    And the total pages is 1
+    And the total results is 2
+
+
+  Scenario: The specified page is negative
+    Given 2 tasks
+    When I request the tasks list with parameters:
+      | PAGE | -1 |
+    Then I get the error "Page cannot be <= 0"
+
+
+  Scenario: Verifying the format shape
+    Given a task:
+      | ID          | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+      | NAME        | Sample Task                          |
+      | DESCRIPTION | A small sample task                  |
+      | STATE       | todo                                 |
+      | PROJECT_ID  | 54f8419c-3f22-4cba-b194-5f8b4727ccfd |
+    When I request the tasks list
+    Then I get the data:
+      """
+      {
+        tasks: [
+          {
+            id: '54f8419c-3f22-4cba-b194-5f8b4727ccfd',
+            name: 'Sample Task',
+            description: 'A small sample task',
+            state: 'todo',
+            project_id: '54f8419c-3f22-4cba-b194-5f8b4727ccfd'
+          }
+        ],
+        count: 1,
+        current_page_number: 1,
+        total_page_count: 1
+      }
+      """

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe V1::ProjectsController do
+  describe 'DELETE /v1/projects/:id' do
+    let(:deleted_project) { FactoryGirl.create(:project) }
+
+    it 'soft-deletes projects by changing their state to disabled' do
+      expect {
+        delete :destroy, id: deleted_project.id
+        deleted_project.reload
+      }
+        .to change(deleted_project, :state).to 'disabled'
+    end
+  end
+end

--- a/spec/controllers/v1/tasks_controller_spec.rb
+++ b/spec/controllers/v1/tasks_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe V1::TasksController do
+  describe 'DELETE /v1/tasks/:id' do
+    let(:deleted_task) { FactoryGirl.create(:task) }
+
+    it 'soft-deletes tasks by changing their state to done' do
+      expect {
+        delete :destroy, id: deleted_task.id
+        deleted_task.reload
+      }
+        .to change(deleted_task, :state).to 'done'
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :uuid             not null, primary key
+#  name        :string
+#  description :text
+#  state       :integer          default(10)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_projects_on_name  (name) UNIQUE
+#
+
 FactoryGirl.define do
   factory :project do
     name

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id               :uuid             not null, primary key
+#  name             :string
+#  description      :string
+#  state            :integer
+#  project_id       :uuid
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :task do
+    name
+    description 'A sample task'
+    state 10
+    project
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id          :uuid             not null, primary key
+#  name        :string
+#  description :text
+#  state       :integer          default(10)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_projects_on_name  (name) UNIQUE
+#
+
 require 'rails_helper'
 
 RSpec.describe Project, type: :model do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id               :uuid             not null, primary key
+#  name             :string
+#  description      :string
+#  state            :integer
+#  project_id       :uuid
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  it { should validate_presence_of :name }
+  it { should validate_uniqueness_of :name }
+  it { should validate_presence_of :state }
+  it { should validate_presence_of :project_id }
+end


### PR DESCRIPTION
- Add Task model
  - Project `has_many` Tasks
  - State initialized as todo
  - cucumber features similar to Project
- Add ListTasks service
  - Entirely the same configuration as ListProjects.
- Add API endpoints for create, show, delete and update task
  - `#index` allows the `project_id` param to enable you to filter by project_id.  
  - `project_id` is required for creation
  - `delete` changes a task's state to `done` -- I assume, however, that an additional state named `disabled` may be more appropriate, to bring it in line with `project`'s state scheme.
- Add controller specs for `tasks#destroy` and `projects#destroy`, to document their soft-deletion behavior.
- Add `byebug` gem.
  - Great for debugging and less of a commitment than `pry`.
- Fix projects controller `find_by :id` to `find_by_id :id`, this was bugged for me, as that is an incorrect use of `find_by`.
- Fix swagger base_api controller, see https://github.com/richhollis/swagger-docs/issues/137
## Potential improvements

Upon introducing `ListTasks`, the pagination behavior cucumber features (which test the default `ListCollection` behavior) would be better placed in a cucumber feature for the `ListCollection` superclass. For now, I've just duplicated some of the pagination tests from `list_projects.feature` to `list_tasks.feature`.
